### PR TITLE
Improve regex by removing backtracking, and fix few bugs in pattern.

### DIFF
--- a/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/copy/ConvertGroovyCopyPasteProcessor.kt
+++ b/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/copy/ConvertGroovyCopyPasteProcessor.kt
@@ -45,7 +45,7 @@ import java.awt.datatransfer.Transferable
 
 // https://regex101.com/r/1OMz6a/1
 private val DECLARATION_REGEX =
-    """(\w+)\s+(?:group:\s*)?["']([^"':]+)(?::|["'],\s*(?:artifact:\s*)?['"])?([^"':]+)(?::|['"],\s*(?:version:\s*)?['"])?([^"':]+)?(?:['"])""".toRegex()
+    """(\w+)\s+(?:group:\s*)?["']([^"':]+)(?::|["'],\s*(?:artifact:\s*)?['"])([^"':]+)(?::|['"],\s*(?:version:\s*)?['"])?([^"':]+)?(?:['"])""".toRegex()
 
 private class MyTransferableData(val text: String) : TextBlockTransferableData {
 

--- a/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/copy/ConvertGroovyCopyPasteProcessor.kt
+++ b/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/copy/ConvertGroovyCopyPasteProcessor.kt
@@ -43,9 +43,9 @@ import org.jetbrains.kotlin.psi.KtFile
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 
-// https://regex101.com/r/kZ258U/3
+// https://regex101.com/r/1OMz6a/1
 private val DECLARATION_REGEX =
-    """(\w+)\s+(?:group:\s+)?["'](.+?)(?::|(?:(?:['"]),\s*(?:artifact:\s*)?(?:['"])))(.+?)(?:(?::|(?:(?:['"]),\s*(?:version:\s*)?(?:['"])))(.*))?(?:['"])""".toRegex()
+    """(\w+)\s+(?:group:\s*)?["']([^"':]+)(?::|["'],\s*(?:artifact:\s*)?['"])?([^"':]+)(?::|['"],\s*(?:version:\s*)?['"])?([^"':]+)?(?:['"])""".toRegex()
 
 private class MyTransferableData(val text: String) : TextBlockTransferableData {
 


### PR DESCRIPTION
**BugFix:**
Detection of non-spaced group starting `group:"..."`

**Improves regex by about 5 fold by removing backtracking and unnecessary groups:**
![Screenshot 2021-02-22 173824](https://user-images.githubusercontent.com/26714676/108707013-76190600-7535-11eb-86e0-1b9d3a17d795.png)
![Screenshot 2021-02-22 173733](https://user-images.githubusercontent.com/26714676/108707026-7b765080-7535-11eb-8faa-cfd4ecdcbfe6.png)

I did not found the regex which detects plugins and etc, but have done some work on optimizing that as well (got the permalink through reddit post):
```
id\s+['"]([^'"]*)['"](?:\s*version\s*['"]([^'"]*)['"])?
```
`\s*` -> `\s+` (need to have a space in order to be a valid groovy syntax)
next are same (removing backtracking).