### PR TITLE
Use latest endpoint instead of manually figuring out latest version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     kotlin("jvm") version "1.5.21"
     kotlin("plugin.serialization") version "1.5.21"
     id("org.jlleitschuh.gradle.ktlint") version "10.1.0"
-    id("org.jetbrains.intellij") version "1.1.3"
+    id("org.jetbrains.intellij") version "1.1.4"
     id("org.jetbrains.changelog") version "1.1.2"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ pluginUntilBuild = 212.*
 pluginVerifierIdeVersions = 2021.1, 2021.1.3, 2021.2
 
 platformType = IC
-platformVersion = 2021.1
+platformVersion = 2021.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/GradleVersion.kt
+++ b/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/GradleVersion.kt
@@ -46,7 +46,7 @@ lateinit var latestGradleVersion: GradleVersion
 
 // https://regex101.com/r/oVpaYd/2
 private val gradleVersionPattern = """([0-9]+)\.([0-9]+)(?:\.([0-9]+))?""".toRegex()
-private const val latestGradleVersionEndpoint = "https://services.gradle.org/versions/all"
+private const val latestGradleVersionEndpoint = "https://services.gradle.org/versions/current"
 private val httpClient = HttpClient {
     install(JsonFeature) {
         val json = kotlinx.serialization.json.Json {
@@ -86,17 +86,12 @@ data class GradleVersion(val major: Int, val minor: Int, val revision: Int?) : C
 }
 
 internal suspend fun fetchGradleVersion() {
-    latestGradleVersion = httpClient.get<List<GradleServiceVersion>>(latestGradleVersionEndpoint)
-        .asSequence()
-        .filter {
-            !it.nightly && !it.snapshot && !it.releaseNightly && !it.activeRc
-        }
-        .mapNotNull { it.version.parseGradleVersion() }
-        .maxOrNull() ?: error("Could not determine latest gradle version")
+    latestGradleVersion = httpClient.get<GradleServiceVersion>(latestGradleVersionEndpoint)
+        .version.parseGradleVersion() ?: error("Could not determine latest gradle version")
 }
 
 /**
- * Github response for latest Gradle release.
+ * Gradle Service response for latest Gradle release.
  */
 @Serializable
 data class GradleServiceVersion(


### PR DESCRIPTION
- Update intellij gradle plugin and test ide
- Use latest version instead of all endpoint

Gradle actually provides an [endpoint](https://services.gradle.org/versions/current) for getting the latest gradle release. The usage of this endpoint also fixes the issue that backport release were treated as newer versions than the actual new versions.

Without this PR:
![image](https://user-images.githubusercontent.com/37078297/130257112-65b1d316-9dab-42c0-bea2-c07cc493f953.png)

With this PR:
![image](https://user-images.githubusercontent.com/37078297/130257771-0b0f8d19-02af-49be-8ed8-81f16766aa6c.png)


