### PR TITLE
Updated to 2021.3 using a workaround resolve #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # IntelliJ Gradle Updater
 
 ## [Unreleased]
+### Changed
+- Update to IntelliJ 2021.3
 ## [2.0.4]
 ### Changed
 - Update to IntelliJ 2021.2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,11 +28,11 @@ fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
     java
-    kotlin("jvm") version "1.5.30"
-    kotlin("plugin.serialization") version "1.5.30"
-    id("org.jlleitschuh.gradle.ktlint") version "10.1.0"
-    id("org.jetbrains.intellij") version "1.1.3"
-    id("org.jetbrains.changelog") version "1.3.0"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.serialization") version "1.6.10"
+    id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+    id("org.jetbrains.intellij") version "1.3.0"
+    id("org.jetbrains.changelog") version "1.3.1"
 }
 
 group = properties("pluginGroup")
@@ -43,10 +43,10 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", "1.2.2")
+    implementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", "1.3.2")
     implementation("io.sentry", "sentry", "5.1.2")
 
-    implementation(platform("io.ktor:ktor-bom:1.6.3"))
+    implementation(platform("io.ktor:ktor-bom:1.6.7"))
     implementation("io.ktor", "ktor-client-okhttp")
     implementation("io.ktor", "ktor-client-serialization-jvm")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", "1.3.2")
-    implementation("io.sentry", "sentry", "5.1.2")
+    implementation("io.sentry", "sentry", "5.5.2")
 
     implementation(platform("io.ktor:ktor-bom:1.6.7"))
     implementation("io.ktor", "ktor-client-okhttp")
@@ -117,6 +117,7 @@ tasks {
 
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
     disabledRules.set(listOf("no-wildcard-imports"))
+    version.set("0.43.2")
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,14 +8,14 @@ pluginVersion = 2.0.5
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 211.*
-pluginUntilBuild = 212.*
+pluginUntilBuild = 213.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2021.2
+pluginVerifierIdeVersions = 2021.3.1
 
 platformType = IC
-platformVersion = 2021.2
+platformVersion = 2021.3.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/GradleVersion.kt
+++ b/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/GradleVersion.kt
@@ -64,6 +64,7 @@ private val httpClient = HttpClient {
  * @property revision the revision version code
  * @see Comparable
  */
+@Suppress("PROVIDED_RUNTIME_TOO_LOW")
 @Serializable(with = GradleVersionSerializer::class)
 data class GradleVersion(val major: Int, val minor: Int, val revision: Int?) : Comparable<GradleVersion> {
     override fun compareTo(other: GradleVersion): Int {
@@ -98,6 +99,7 @@ internal suspend fun fetchGradleVersion() {
 /**
  * Github response for latest Gradle release.
  */
+@Suppress("PROVIDED_RUNTIME_TOO_LOW")
 @Serializable
 data class GradleServiceVersion(
     val version: String,

--- a/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/inspection/dependencies/kotlin/redundant_version/RedundantVersionInspection.kt
+++ b/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/inspection/dependencies/kotlin/redundant_version/RedundantVersionInspection.kt
@@ -36,7 +36,7 @@ import me.schlaubi.intellij_gradle_version_checker.util.calleeFunction
 import me.schlaubi.intellij_gradle_version_checker.util.isSimple
 import me.schlaubi.intellij_gradle_version_checker.util.simpleValue
 import me.schlaubi.intellij_gradle_version_checker.util.stringValue
-import org.jetbrains.kotlin.idea.inspections.gradle.getResolvedKotlinGradleVersion
+import org.jetbrains.kotlin.idea.groovy.inspections.getResolvedKotlinGradleVersion
 import org.jetbrains.kotlin.idea.util.module
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile

--- a/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/inspection/dependencies/kotlin/stdlib/DependencyOnStdlibInspection.kt
+++ b/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/inspection/dependencies/kotlin/stdlib/DependencyOnStdlibInspection.kt
@@ -35,7 +35,7 @@ import me.schlaubi.intellij_gradle_version_checker.inspection.dependencies.Depen
 import me.schlaubi.intellij_gradle_version_checker.util.calleeFunction
 import me.schlaubi.intellij_gradle_version_checker.util.isSimple
 import me.schlaubi.intellij_gradle_version_checker.util.simpleValue
-import org.jetbrains.kotlin.idea.inspections.gradle.getResolvedKotlinGradleVersion
+import org.jetbrains.kotlin.idea.groovy.inspections.getResolvedKotlinGradleVersion
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression

--- a/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/inspection/dependencies/kotlin/unnecessary_coordinates/KotlinInspectionWithCoordinatesInspection.kt
+++ b/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/inspection/dependencies/kotlin/unnecessary_coordinates/KotlinInspectionWithCoordinatesInspection.kt
@@ -36,7 +36,7 @@ import me.schlaubi.intellij_gradle_version_checker.util.equalsString
 import me.schlaubi.intellij_gradle_version_checker.util.isSimple
 import me.schlaubi.intellij_gradle_version_checker.util.simpleValue
 import me.schlaubi.intellij_gradle_version_checker.util.startsWith
-import org.jetbrains.kotlin.idea.inspections.gradle.getResolvedKotlinGradleVersion
+import org.jetbrains.kotlin.idea.groovy.inspections.getResolvedKotlinGradleVersion
 import org.jetbrains.kotlin.idea.util.module
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile

--- a/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/settings/GradleVersionSettings.kt
+++ b/src/main/kotlin/me/schlaubi/intellij_gradle_version_checker/settings/GradleVersionSettings.kt
@@ -24,8 +24,8 @@
 
 package me.schlaubi.intellij_gradle_version_checker.settings
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.project.Project
@@ -71,7 +71,7 @@ class ApplicationPersistentGradleVersionSettings :
     AbstractPersistentGradleVersionSettings<ApplicationPersistentGradleVersionSettings>() {
     companion object {
         fun getInstance(): GradleVersionSettings =
-            ServiceManager.getService(ApplicationPersistentGradleVersionSettings::class.java)
+            ApplicationManager.getApplication().getService(ApplicationPersistentGradleVersionSettings::class.java)
     }
 }
 
@@ -94,7 +94,7 @@ class ProjectPersistentGradleVersionSettings :
     companion object {
         @JvmStatic
         fun getInstance(project: Project): GradleVersionSettings =
-            ServiceManager.getService(project, ProjectPersistentGradleVersionSettings::class.java)
+            project.getService(ProjectPersistentGradleVersionSettings::class.java)
     }
 }
 


### PR DESCRIPTION
I tried to update to 1.3.2 and then I used a workaround describe in https://github.com/Kotlin/kotlinx.serialization/issues/993#issuecomment-984742051.
I'm not sure how to verify that it work, I just ran gradlew buildPlugin and it succeeded.